### PR TITLE
Remove roles from connections migration

### DIFF
--- a/database/migrations/20200212120642_connect_table.js
+++ b/database/migrations/20200212120642_connect_table.js
@@ -10,24 +10,10 @@ exports.up = function(knex, Promise) {
       .onUpdate('CASCADE')
       .onDelete('CASCADE');
     tbl
-      .string('connector_role', 50)
-      .notNullable()
-      .references('roles')
-      .inTable('users')
-      .onUpdate('CASCADE')
-      .onDelete('CASCADE');
-    tbl
       .integer('connected_id')
       .unsigned()
       .notNullable()
       .references('id')
-      .inTable('users')
-      .onUpdate('CASCADE')
-      .onDelete('CASCADE');
-    tbl
-      .string('connected_role', 50)
-      .notNullable()
-      .references('roles')
       .inTable('users')
       .onUpdate('CASCADE')
       .onDelete('CASCADE');


### PR DESCRIPTION
# Description

The connections migration had a foreign key that was referencing a column in the users table that did not have a unique constraint, so the migration was throwing an error. This merge removes the roles column that was causing the problem

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code
