### PR TITLE
Add parseIn() to post router

### DIFF
--- a/api/users/index.js
+++ b/api/users/index.js
@@ -257,8 +257,8 @@ router.post('/connect/:id', async (req, res) => {
   }
 
   const connectionData = {
-    connector_id: req.params.id,
-    connected_id: req.body
+    connector_id: parseInt(req.params.id),
+    connected_id: parseInt(req.body)
   };
 
   try {


### PR DESCRIPTION
# Description

Added parseInt() function to the POST endpoint for the connections

## Checklist

Remove any items which are not applicable.

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works AND the tests pass
