### PR TITLE
Add skills array to GET/PUT user endpoints

### DIFF
--- a/api/users/index.js
+++ b/api/users/index.js
@@ -179,7 +179,6 @@ router.put('/:id', restricted, mw.upload.single('photo'), async (req, res) => {
         .status(401)
         .json({ message: 'You may not modify this profile!' });
     }
-
     const editUser = await Users.update(newUser, id);
 
     if (editUser) {

--- a/models/usersModel.js
+++ b/models/usersModel.js
@@ -308,7 +308,7 @@ async function update(user, id) {
   const triggerUsers = isEmpty(pick(user, userColumns));
   const triggerConservationists = isEmpty(pick(user, conservationistColumns));
   const triggerSupporters = isEmpty(pick(user, supporterColumns));
-  const triggerSkills = user.skils && Array.isArray(user.skills);
+  const triggerSkills = user.skills && Array.isArray(user.skills);
 
   if (triggerUsers) {
     await updateUsersTable(user, id);

--- a/util/pick.js
+++ b/util/pick.js
@@ -1,0 +1,13 @@
+/**
+ * Picks all properties listed in the `props` array from an object.
+ * @param obj object to pick properties from
+ * @param props array of properties to pick from the object
+ * @returns {{}|{[p: string]: *}} subobject of obj containing only the properties requested
+ */
+function pick(obj, props) {
+  return Object.keys(obj)
+    .filter(key => props.includes(key))
+    .reduce((picked, key) => ({ ...picked, [key]: obj[key] }), {});
+}
+
+module.exports = pick;


### PR DESCRIPTION
Added the skills array to:
 - GET /api/users
 - GET /api/users/:id
 - GET /api/users/sub/:sub
 - PUT /api/users/:id

This allows users to update their skills via the PUT endpoint, and
introduces some consistency between the PUT request body and response,
and the rest of the GET routes.

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
