### PR TITLE
updated CI/CD config to deploy tagged releases to production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,6 @@ jobs:
             - node_modules
       - run:
           command: npm run lint
-
   deploy_staging:
     machine:
       enabled: true
@@ -24,7 +23,6 @@ jobs:
       - checkout
       - run:
           command: git push -f https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_STAGING_APP.git master
-
   deploy_production:
     machine:
       enabled: true
@@ -38,6 +36,7 @@ workflows:
   test_and_deploy:
     jobs:
       - lint:
+          # since deploy_production is triggered by tags and depends on lint, lint must also be triggered on tags
           filters:
             tags:
               only: /.*/
@@ -53,5 +52,6 @@ workflows:
           filters:
             tags:
               only: /.*/
+            # deploy_production can only be triggered by a tag, not by a regular commit
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,41 @@ jobs:
       - run:
           command: npm run lint
 
+  deploy_staging:
+    machine:
+      enabled: true
+    steps:
+      - checkout
+      - run:
+          command: git push -f https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_STAGING_APP.git master
+
+  deploy_production:
+    machine:
+      enabled: true
+    steps:
+      - checkout
+      - run:
+          command: git push -f https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_PRODUCTION_APP.git master
+
 workflows:
   version: 2
   test_and_deploy:
     jobs:
-      - lint
+      - lint:
+          filters:
+            tags:
+              only: /.*/
+      - deploy_staging:
+          requires:
+            - lint
+          filters:
+            branches:
+              only: master
+      - deploy_production:
+          requires:
+            - lint
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
This PR lets us use a single base branch (`master`) for both our staging and production apps. All PRs to the base branch deploy to the staging app, but only tagged releases deploy to the production app.