### PR TITLE
implemented comments for campaign posts

### DIFF
--- a/app/database/migrations/20300000000001_comment_on_posts.js
+++ b/app/database/migrations/20300000000001_comment_on_posts.js
@@ -1,0 +1,8 @@
+const TABLE_NAME = 'comments';
+exports.up = (knex, Promise) => knex.schema.alterTable(TABLE_NAME, (table) => {
+  table.renameColumn('campaign_id', 'post_id');
+});
+
+exports.down = (knex, Promise) => knex.schema.table(TABLE_NAME, (table) => {
+  table.renameColumn('post_id', 'campaign_id');
+});


### PR DESCRIPTION
Users can now comment on any campaign post, including campaign updates.