### PR TITLE
add skilled impact requests and project goals response to feed

### DIFF
--- a/app/database/models/campaignPostsModel.js
+++ b/app/database/models/campaignPostsModel.js
@@ -12,6 +12,8 @@ async function getMostRecentPosts(startAt = undefined, size = 8, date) {
   let posts = db('campaign_posts')
     .join('campaigns', 'campaign_posts.campaign_id', 'campaigns.id')
     .join('users', 'campaigns.user_id', 'users.id')
+    .leftJoin('skilled_impact_requests', 'campaigns.id', 'skilled_impact_requests.campaign_id')
+    .leftJoin('project_goals', 'skilled_impact_requests.id', 'project_goals.skilled_impact_request_id')
     .leftJoin('conservationists', 'users.id', 'conservationists.user_id')
     .leftJoin('comments', 'comments.campaign_id', 'campaign_posts.campaign_id')
     .whereNot('users.is_deactivated', true)
@@ -26,9 +28,14 @@ async function getMostRecentPosts(startAt = undefined, size = 8, date) {
       'users.location',
       'users.profile_image',
       'conservationists.name as org_name',
+      // use distinct to eliminate duplicate rows from left joins
       db.raw(
         // eslint-disable-next-line quotes
-        `ARRAY_AGG(json_build_object('id', comments.id, 'user_id', comments.user_id, 'created_at', comments.created_at, 'body', comments.body)) filter (where comments.id is not null) as comments`,
+        `ARRAY_AGG(DISTINCT jsonb_build_object('id', skilled_impact_requests.id, 'skill', skilled_impact_requests.skill, 'project_goals', (select json_agg(project_goals) FROM (SELECT * FROM project_goals WHERE skilled_impact_request_id = skilled_impact_requests.id) AS project_goals))) FILTER (WHERE skilled_impact_requests.id IS NOT null) AS skilled_impact_requests`,
+      ),
+      db.raw(
+        // eslint-disable-next-line quotes
+        `ARRAY_AGG(DISTINCT jsonb_build_object('id', comments.id, 'user_id', comments.user_id, 'created_at', comments.created_at, 'body', comments.body)) filter (where comments.id is not null) as comments`,
       ),
     )
     .groupBy(
@@ -40,6 +47,7 @@ async function getMostRecentPosts(startAt = undefined, size = 8, date) {
       'users.location',
       'users.profile_image',
       'conservationists.name',
+      'skilled_impact_requests.id',
     )
     .limit(72);
 

--- a/app/database/models/campaignPostsModel.js
+++ b/app/database/models/campaignPostsModel.js
@@ -31,7 +31,7 @@ async function getMostRecentPosts(startAt = undefined, size = 8, date) {
       // use distinct to eliminate duplicate rows from left joins
       db.raw(
         // eslint-disable-next-line quotes
-        `ARRAY_AGG(DISTINCT jsonb_build_object('id', skilled_impact_requests.id, 'skill', skilled_impact_requests.skill, 'project_goals', (select json_agg(project_goals) FROM (SELECT * FROM project_goals WHERE skilled_impact_request_id = skilled_impact_requests.id) AS project_goals))) FILTER (WHERE skilled_impact_requests.id IS NOT null) AS skilled_impact_requests`,
+        `ARRAY_AGG(DISTINCT jsonb_build_object('id', skilled_impact_requests.id, 'skill', skilled_impact_requests.skill, 'project_goals', (select json_agg(project_goals) FROM (SELECT id, goal_title, description FROM project_goals WHERE skilled_impact_request_id = skilled_impact_requests.id) AS project_goals))) FILTER (WHERE skilled_impact_requests.id IS NOT null) AS skilled_impact_requests`,
       ),
       db.raw(
         // eslint-disable-next-line quotes


### PR DESCRIPTION
# Description

Add skilled impact requests and nested project goals response to GET /feed/

Sample response:

```
{
    ...feed.body,
    "skilled_impact_requests": [
            {
                "id": 1,
                "skill": "ARCHITECTURE",
                "project_goals": [
                    {
                        "id": 1,
                        "goal_title": "Design a dam",
                        "description": "Design a dam for a family of beavers"
                    },
                    {
                        "id": 2,
                        "goal_title": "Write instructions for building a dam",
                        "description": "Should include materials required and progress pictures"
                    }
                ]
            }
        ],
}
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
